### PR TITLE
Fix image path

### DIFF
--- a/bin/gitdown
+++ b/bin/gitdown
@@ -132,6 +132,8 @@ while ($line < @input) {
             # remove double /
             $subpath =~ s|/+|/|g;
             $imgpath .= $subpath;
+	    # remove starting /
+	    $imgpath =~ s|^/+||;
         }
         elsif (/^\.toc(\s+([1-9]))?/) {
             #   Determine top level in text after .toc


### PR DESCRIPTION
When you set branch and prebranch to empty
```
.set BRANCH=
.set PREBRANCH=
```

And include an image, say:

```
[diagram]
---->
[/diagram/
```

You would want the url to be as follows
```
<img src="images/README_1.png" alt="1">
```

Previously, you would get instead:
```
<img src="//images/README_1.png" alt="1">
```

This commit removes spurious slashes in front of the url.

Of course this breaks protocol-relative urls...